### PR TITLE
try to have G and gg reespect the goal column

### DIFF
--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -397,7 +397,8 @@ class MoveToFirstLine extends Motion
     0
 
   moveCursor: (cursor) ->
-    cursor.setBufferPosition [@getRow(), cursor.getBufferColumn()]
+    cursor.goalColumn = cursor.getBufferColumn()
+    cursor.setBufferPosition [@getRow(), cursor.goalColumn]
 
 # keymap: G
 class MoveToLastLine extends MoveToFirstLine

--- a/spec/motion-spec.coffee
+++ b/spec/motion-spec.coffee
@@ -810,6 +810,17 @@ describe "Motion", ->
           selectedText: "  2\n 3a"
           cursor: [2, 3]
 
+  describe "the G and gg keybindings", ->
+    it "saves the top goal position", ->
+      set text: "12345\n123\n", cursor: [0, 4]
+      ensure 'G', cursor: [1, 2]
+      ensure 'gg', cursor: [0, 4]
+
+    it "saves the bottom goal position", ->
+      set text: "123\n12345\n", cursor: [1, 4]
+      ensure 'gg', cursor: [0, 2]
+      ensure 'G', cursor: [1, 4]
+
   describe "the N% keybinding", ->
     beforeEach ->
       set


### PR DESCRIPTION
On top of Vim preserving the column when jumping with `gg` and `G` (#77), Vim also sets the goal column for further motion.

That way, if you have a file (where O is the cursor):

```
aaaaaaaaaaaaaO
bb
```

and you type `G` `gg`, the cursor goes right back where it started.

Right now, vim-mode-plus's behavior moves the cursor back to the first line, but to the second column instead of the last column.

This was my attempt to fix this problem.  Unfortunately, I can't figure out how to get vim-mode-plus to recognize the goal column.  Was hoping you knew.

If not, feel free to close.
